### PR TITLE
Small tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,10 @@ celerybeat-schedule
 .venv
 venv/
 ENV/
+bin/
+lib/
+share/
+include/
 
 # Spyder project settings
 .spyderproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ wpilib<2018
 pyfrc<2018
 numpy
 flake8
+pygame


### PR DESCRIPTION
2 tweaks & 1 nitpick:

1. add virtualenv folders (`bin`, `lib`, `share`, and `include`) to the gitignore so we don't end up pushing a bunch of random binaries up there.
2. add `pygame` as a dependency to `requirements.txt`, so that the robot simulator can use it for joystick support if we ever need to test teleop.

Nitpick: the [dragonrobotics/2018-PowerUp](https://github.com/dragonrobotics/2018-PowerUp) repository needs to be tagged with `team5002` per our [guidelines](https://github.com/dragonrobotics/dragonrobotics.github.io/blob/master/index.md#git-and-github).